### PR TITLE
Fix: Crash if TextToSpeech not defined

### DIFF
--- a/src/android/SpeechSynthesis.java
+++ b/src/android/SpeechSynthesis.java
@@ -183,7 +183,7 @@ public class SpeechSynthesis extends CordovaPlugin implements OnInitListener, On
      * @param status
      */
     public void onInit(int status) {
-        if (status == TextToSpeech.SUCCESS) {
+        if (mTts != null && status == TextToSpeech.SUCCESS) {
             state = SpeechSynthesis.STARTED;
             JSONArray voices = new JSONArray();
             JSONObject voice;


### PR DESCRIPTION
TextToSpeech may be undefined and still call onInit, this provide a safe call. (overwise it crash the app)
